### PR TITLE
Migrated runs-on to self hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ env:
 
 jobs:
   GetVersion:
-    runs-on: ubuntu-20.04
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: mcr.microsoft.com/dotnet/sdk:8.0
     outputs:
       ShortVersion: ${{ steps.gitversion.outputs.ShortVersion }}
       GitVersion: ${{ steps.gitversion.outputs.GitVersion }}
@@ -24,7 +27,10 @@ jobs:
         uses: opentap/get-gitversion@v1.1
 
   Build:
-    runs-on: ubuntu-latest
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: mcr.microsoft.com/dotnet/sdk:8.0
     needs: GetVersion
     env:
       ShortVersion: ${{ needs.GetVersion.outputs.ShortVersion }}
@@ -38,15 +44,17 @@ jobs:
           # A fetch-depth of 0 ensures we get a complete history.
           fetch-depth: 0 
       # Fixes an issue with actions/checkout@v3. See https://github.com/actions/checkout/issues/290
+      
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} 
+      
       - name: Build
         run: |
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $TAP_SIGN_CERT
           dotnet build -c Release ./OpenTap.Metrics/OpenTap.Metrics.csproj
         env:
-          TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
+          TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS_INTERNAL }}
           TAP_SIGN_AUTH: ${{ secrets.TAP_SIGN_AUTH }}
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
           KS8500_REPO_TOKEN: ${{ secrets.KS8500_REPO_TOKEN }}
@@ -54,6 +62,7 @@ jobs:
           SIGN_VERSION: "1.5.0-alpha.4.9+6a5355a8.sign-apple-apps"
       # Upload the package so it can be downloaded from GitHub, 
       # and consumed by other steps in this workflow
+      
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
@@ -63,27 +72,36 @@ jobs:
             bin/Release/*.TapPackage
 
   UnitTests:
-    runs-on: ubuntu-latest
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: mcr.microsoft.com/dotnet/sdk:8.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      
       - name: Build
         run: dotnet test
 
 
   publish:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: mcr.microsoft.com/dotnet/sdk:8.0
     needs: Build
     steps:
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
           name: tap-package
+
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@v1.0
+        uses: opentap/setup-opentap@main
         with:
-          version: 9.18.4
+          version: 9.23.0
           packages: 'Repository Client:1.0'
+      
       - name: Publish Packages
         run: tap repo upload --repository https://packages.opentap.io --token ${{ secrets.PUBLIC_REPO_TOKEN }} *.TapPackage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_CONSOLE_ANSI_COLOR: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   GetVersion:
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
         uses: opentap/get-gitversion@main
 
   Build:
-    runs-on: [self-hosted, Windows]
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     needs: GetVersion
     env:
       ShortVersion: ${{ needs.GetVersion.outputs.ShortVersion }}
@@ -46,10 +49,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} 
 
-      # - name: Setup .NET
-      #   uses: actions/setup-dotnet@v4
-      #   with:
-      #     dotnet-version: 6.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
 
       - name: Build
         run: |
@@ -74,15 +77,18 @@ jobs:
             bin/Release/*.TapPackage
 
   UnitTests:
-    runs-on: [self-hosted, Windows]
+    runs-on:
+       group: OpenTAP-SpokeVPC
+       labels:  [Linux, X64]
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # - name: Setup .NET
-      #   uses: actions/setup-dotnet@v4
-      #   with:
-      #     dotnet-version: 6.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
 
       - name: Build
         run: dotnet test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_CONSOLE_ANSI_COLOR: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   GetVersion:
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     outputs:
       ShortVersion: ${{ steps.gitversion.outputs.ShortVersion }}
       GitVersion: ${{ steps.gitversion.outputs.GitVersion }}
@@ -30,7 +34,7 @@ jobs:
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     needs: GetVersion
     env:
       ShortVersion: ${{ needs.GetVersion.outputs.ShortVersion }}
@@ -80,7 +84,7 @@ jobs:
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,7 +103,7 @@ jobs:
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     needs: Build
     steps:
       - name: Download binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       # The get-gitversion action installs OpenTAP and fetches with fetch-depth: 0
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@v1.1
+        uses: opentap/get-gitversion@main
 
   Build:
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,7 @@ jobs:
         uses: opentap/get-gitversion@main
 
   Build:
-    runs-on:
-       group: OpenTAP-SpokeVPC
-       labels:  [Linux, X64]
-    container: ghcr.io/opentap/oci-images/build-dotnet:latest
+    runs-on: [self-hosted, Windows]
     needs: GetVersion
     env:
       ShortVersion: ${{ needs.GetVersion.outputs.ShortVersion }}
@@ -53,10 +50,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} 
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
+      # - name: Setup .NET
+      #   uses: actions/setup-dotnet@v4
+      #   with:
+      #     dotnet-version: 6.0.x
 
       - name: Build
         run: |
@@ -81,10 +78,7 @@ jobs:
             bin/Release/*.TapPackage
 
   UnitTests:
-    runs-on:
-       group: OpenTAP-SpokeVPC
-       labels:  [Linux, X64]
-    container: ghcr.io/opentap/oci-images/build-dotnet:latest
+    runs-on: [self-hosted, Windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} 
-      
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
       - name: Build
         run: |
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $TAP_SIGN_CERT
@@ -79,7 +84,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
       - name: Build
         run: dotnet test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
           TAP_SIGN_AUTH: ${{ secrets.TAP_SIGN_AUTH }}
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
           KS8500_REPO_TOKEN: ${{ secrets.KS8500_REPO_TOKEN }}
-          DOTFUSCATOR_VERSION: "2.0.2-beta.6+11a5bc9a"
           SIGN_VERSION: "1.4.0"
       # Upload the package so it can be downloaded from GitHub, 
       # and consumed by other steps in this workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
           KS8500_REPO_TOKEN: ${{ secrets.KS8500_REPO_TOKEN }}
           DOTFUSCATOR_VERSION: "2.0.2-beta.6+11a5bc9a"
-          SIGN_VERSION: "1.5.0-alpha.4.9+6a5355a8.sign-apple-apps"
+          SIGN_VERSION: "1.4.0"
       # Upload the package so it can be downloaded from GitHub, 
       # and consumed by other steps in this workflow
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 6.0.x
+      # - name: Setup .NET
+      #   uses: actions/setup-dotnet@v4
+      #   with:
+      #     dotnet-version: 6.0.x
 
       - name: Build
         run: dotnet test

--- a/OpenTap.Metrics/OpenTap.Metrics.csproj
+++ b/OpenTap.Metrics/OpenTap.Metrics.csproj
@@ -42,7 +42,6 @@
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
     <OpenTapPackageReference Include="Sign" Version="$(SIGN_VERSION)" Reference="False" Repository="https://test-automation.pw.keysight.com/api/packages" Token="$(KS8500_REPO_TOKEN)" />
     <OpenTapPackageReference Include="Keg" Version="0.1.0" Reference="False" />
-    <OpenTapPackageReference Include="Dotfuscator" Version="$(DOTFUSCATOR_VERSION)" Reference="False" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Migrated runners to self hosted in order for fixing the compliance on https://github.com/opentap/KS8400/issues/1068