### PR TITLE
Added support for nullable metrics

### DIFF
--- a/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
+++ b/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
@@ -39,15 +39,43 @@ public class DynamicMetricTests
         }
     }
 
+    public class DynamicNullableMetricProvider : Instrument, IAdditionalMetricSources, IOnPollMetricsCallback
+    {
+        const string Group = "Dynamic Nullable Metric Test";
+        IEnumerable<MetricInfo> IAdditionalMetricSources.AdditionalMetrics => new[] { PollMetric, PushMetric };
+        public MetricInfo PollMetric { get; }
+        public MetricInfo PushMetric { get; }
+
+        public double? Counter { get; private set; } = 0;
+
+        public DynamicNullableMetricProvider()
+        {
+            PollMetric = MetricManager.CreateNullablePollMetric(this, () => Counter, "Counter", Group);
+            PushMetric = MetricManager.CreateNullablePushMetric<double?>(this, "Pusher", Group);
+        }
+
+        public void PushDouble(double? value)
+        {
+            if (value is null)
+                MetricManager.PushMetric(PushMetric);
+            else
+                MetricManager.PushMetric(PushMetric, value.Value);
+        }
+
+        public void OnPollMetrics(IEnumerable<MetricInfo> metrics)
+        {
+            if (metrics.Contains(PollMetric))
+                Counter++;
+        }
+    }
+
     public class DynamicMetricListener : IMetricListener
     {
         public object LastMetric { get; private set; }
         public void OnPushMetric(IMetric table)
         {
-            if (table.Info.MetricFullName == "Dynamic Metric Test / Pusher")
-            {
+            if (table.Info.MetricFullName is "Dynamic Metric Test / Pusher" or "Dynamic Nullable Metric Test / Pusher")
                 LastMetric = table.Value;
-            }
         }
     }
 
@@ -92,6 +120,50 @@ public class DynamicMetricTests
             IMetric m = MetricManager.PollMetrics(new[] { dyn.PollMetric }).First();
             Assert.AreEqual(i, m.Value);
             Assert.AreEqual(i, dyn.Counter);
+        }
+    }
+
+    [Test]
+    public void TestNewMetric_Nullable()
+    {
+        MetricManager.Reset();
+        using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+        MetricInfo result = null;
+        void onNewMetric(MetricCreatedEventArgs args)
+        {
+            MetricManager.OnMetricCreated -= onNewMetric;
+            result = args.Metric;
+        }
+        var provider = new DynamicNullableMetricProvider();
+        MetricManager.OnMetricCreated += onNewMetric;
+        var created = MetricManager.CreateNullablePushMetric<double?>(provider, "test", "group");
+        Assert.That(created, Is.Not.Null);
+        Assert.That(result, Is.EqualTo(created));
+    }
+
+    [Test]
+    public void TestDynamicMetrics_Nullable()
+    {
+        MetricManager.Reset();
+        using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+        var provider = new DynamicNullableMetricProvider();
+        InstrumentSettings.Current.Add(provider);
+        var listener = new DynamicMetricListener();
+        MetricManager.Subscribe(listener, new[] { provider.PushMetric });
+        Assert.That(listener.LastMetric, Is.Null);
+
+        for (double i = 0; i < 10; i++)
+        {
+            provider.PushDouble(i);
+            Assert.That(listener.LastMetric, Is.EqualTo(i));
+        }
+
+        for (double i = 1; i < 10; i++)
+        {
+            // DynamicNullableMetricProvider is incrementing Counter whenever it is polled
+            IMetric m = MetricManager.PollMetrics(new[] { provider.PollMetric }).First();
+            Assert.That(m.Value, Is.EqualTo(i));
+            Assert.That(provider.Counter, Is.EqualTo(i));
         }
     }
 }

--- a/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
+++ b/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
@@ -50,8 +50,8 @@ public class DynamicMetricTests
 
         public DynamicNullableMetricProvider()
         {
-            PollMetric = MetricManager.CreateNullablePollMetric(this, () => Counter, "Counter", Group);
-            PushMetric = MetricManager.CreateNullablePushMetric<double?>(this, "Pusher", Group);
+            PollMetric = MetricManager.CreatePollMetric(this, () => Counter, "Counter", Group);
+            PushMetric = MetricManager.CreatePushMetric<double?>(this, "Pusher", Group);
         }
 
         public void PushDouble(double? value)
@@ -136,7 +136,7 @@ public class DynamicMetricTests
         }
         var provider = new DynamicNullableMetricProvider();
         MetricManager.OnMetricCreated += onNewMetric;
-        var created = MetricManager.CreateNullablePushMetric<double?>(provider, "test", "group");
+        var created = MetricManager.CreatePushMetric<double?>(provider, "test", "group");
         Assert.That(created, Is.Not.Null);
         Assert.That(result, Is.EqualTo(created));
     }

--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -199,6 +199,22 @@ public class MetricManagerTest
     }
 
     [Test]
+    public void TestMetricTypes_MetricSource()
+    {
+        MetricManager.Reset();
+        var metricInfos = MetricManager.GetMetricInfos().Where(m => m.Source is FullMetricSource).ToArray();
+
+        Assert.That(metricInfos, Has.Length.EqualTo(7));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "DoubleMetric" && m.Type.HasFlag(MetricType.Double)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "DoubleMetricNull" && m.Type.HasFlag(MetricType.Double | MetricType.Nullable)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "BoolMetric" && m.Type.HasFlag(MetricType.Boolean)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "BoolMetricNull" && m.Type.HasFlag(MetricType.Boolean | MetricType.Nullable)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "IntMetric" && m.Type.HasFlag(MetricType.Double)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "IntMetricNull" && m.Type.HasFlag(MetricType.Double | MetricType.Nullable)));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.Name == "StringMetric" && m.Type.HasFlag(MetricType.String)));
+    }
+
+    [Test]
     public void TestHasInterest()
     {
         MetricManager.Reset();

--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -369,4 +369,31 @@ public class MetricManagerTest
         var results2 = listener.MetricValues.ToArray();
         Assert.AreEqual(0, results2.Length);
     }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void TestPushMetricRetainAvailability_WhenMetricInfoIsRetrieved(bool isAvailable, bool expected)
+    {
+        MetricManager.Reset();
+        var source = new FullMetricSource();
+        var metricInfo = MetricManager.GetMetricInfo(source, nameof(source.DoubleMetric));
+        MetricManager.UpdateAvailability(metricInfo, isAvailable);
+
+        metricInfo = MetricManager.GetMetricInfo(source, nameof(source.DoubleMetric));
+
+        Assert.That(metricInfo.IsAvailable, Is.EqualTo(expected));
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void TestPushMetricRetainAvailability_WhenMetricInfosAreRetrieved(bool isAvailable, bool expected)
+    {
+        MetricManager.Reset();
+        var metricInfo = MetricManager.GetMetricInfos().Where(m => m.Source is FullMetricSource).First(m => m.Name == nameof(FullMetricSource.DoubleMetric));
+        MetricManager.UpdateAvailability(metricInfo, isAvailable);
+
+        metricInfo = MetricManager.GetMetricInfos().Where(m => m.Source is FullMetricSource).First(m => m.Name == nameof(FullMetricSource.DoubleMetric));
+
+        Assert.That(metricInfo.IsAvailable, Is.EqualTo(expected));
+    }
 }

--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -215,6 +215,23 @@ public class MetricManagerTest
     }
 
     [Test]
+    public void TestMetricAvailability_MetricSource()
+    {
+        MetricManager.Reset();
+        var interestSet = MetricManager.GetMetricInfos().Where(m => m.Source is FullMetricSource).ToArray();
+        var metricInfos = MetricManager.PollMetrics(interestSet).ToArray();
+
+        Assert.That(metricInfos, Has.Length.EqualTo(7));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "DoubleMetric" && m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "DoubleMetricNull" && !m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "BoolMetric" && m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "BoolMetricNull" && !m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "IntMetric" && m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "IntMetricNull" && !m.Info.IsAvailable));
+        Assert.That(metricInfos, Has.One.Matches<IMetric>(m => m.Info.Name == "StringMetric" && !m.Info.IsAvailable));
+    }
+
+    [Test]
     public void TestHasInterest()
     {
         MetricManager.Reset();

--- a/OpenTap.Metrics/EmptyMetric.cs
+++ b/OpenTap.Metrics/EmptyMetric.cs
@@ -1,0 +1,32 @@
+﻿//            Copyright Keysight Technologies 2012-2024
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+
+namespace OpenTap.Metrics;
+
+public readonly struct EmptyMetric : IMetric
+{
+    /// <summary> The metric information. </summary>
+    public MetricInfo Info { get; }
+
+    /// <summary> The value of the metric. </summary>
+    public object Value => null;
+
+    /// <summary> The time the metric was recorded. </summary>
+    public DateTime Time { get; }
+
+    /// <summary> Creates a new instance of the empty metric. </summary>
+    public EmptyMetric(MetricInfo info, DateTime? time = null)
+    {
+        Info = info;
+        Time = time ?? DateTime.Now;
+    }
+
+    /// <summary> Returns a string representation of the empty metric. </summary>
+    public override string ToString()
+    {
+        return $"{Info.MetricFullName}: {Value} at {Time}";
+    }
+}

--- a/OpenTap.Metrics/MetricAvailabilityChangedEventsArgs.cs
+++ b/OpenTap.Metrics/MetricAvailabilityChangedEventsArgs.cs
@@ -1,0 +1,19 @@
+﻿//            Copyright Keysight Technologies 2012-2024
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+
+namespace OpenTap.Metrics;
+
+/// <summary> Provides data for the MetricAvailabilityChanged event. </summary>
+public class MetricAvailabilityChangedEventsArgs : EventArgs
+{
+    internal MetricAvailabilityChangedEventsArgs(MetricInfo metric)
+    {
+        Metric = metric;
+    }
+
+    /// <summary> The metric that had its availability changed. </summary>
+    public MetricInfo Metric { get; }
+}

--- a/OpenTap.Metrics/MetricCreatedEventArgs.cs
+++ b/OpenTap.Metrics/MetricCreatedEventArgs.cs
@@ -17,4 +17,3 @@ public class MetricCreatedEventArgs : EventArgs
     /// <summary> The metric that was created. </summary>
     public MetricInfo Metric { get; }
 }
-

--- a/OpenTap.Metrics/MetricInfo.cs
+++ b/OpenTap.Metrics/MetricInfo.cs
@@ -35,6 +35,9 @@ public class MetricInfo
     /// <summary> The name of the metric. </summary>
     public string Name { get; }
 
+    /// <summary> Indicates if the metric is available for polling. </summary>
+    public bool IsAvailable { get; internal set; }
+
     /// <summary> Creates a new metric info based on a member name. </summary>
     /// <param name="mem">The metric member object.</param>
     /// <param name="groupName">The name of the metric group.</param>
@@ -49,6 +52,7 @@ public class MetricInfo
         Type = GetMetricType(mem);
         Name = metricAttr?.Name ?? Member.GetDisplayAttribute()?.Name;
         Source = source;
+        IsAvailable = true;
     }
 
     /// <summary> Creates a new metric info based on custom data. </summary>
@@ -65,6 +69,7 @@ public class MetricInfo
         Attributes = attributes;
         Kind = kind;
         Source = source;
+        IsAvailable = true;
     }
 
     /// <summary>

--- a/OpenTap.Metrics/MetricInfo.cs
+++ b/OpenTap.Metrics/MetricInfo.cs
@@ -21,7 +21,7 @@ public class MetricInfo
     public MetricType Type { get; }
 
     /// <summary> The metric member object. </summary>
-    IMemberData Member { get; }
+    internal IMemberData Member { get; }
 
     /// <summary> The attributes of the metric. </summary>
     public IEnumerable<object> Attributes { get; }
@@ -35,7 +35,7 @@ public class MetricInfo
     /// <summary> The name of the metric. </summary>
     public string Name { get; }
 
-    /// <summary> Indicates if the metric is available for polling. </summary>
+    /// <summary> Indicates if the metric is available. </summary>
     public bool IsAvailable { get; internal set; }
 
     /// <summary> Creates a new metric info based on a member name. </summary>
@@ -89,7 +89,8 @@ public class MetricInfo
             return string.Equals(GroupName, o.GroupName, StringComparison.Ordinal) &&
                    string.Equals(Name, o.Name, StringComparison.Ordinal) &&
                    Equals(Member, o.Member) &&
-                   Equals(Source, o.Source);
+                   Equals(Source, o.Source) &&
+                   Equals(IsAvailable, o.IsAvailable);
 
         return false;
     }

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -99,7 +99,12 @@ public static class MetricManager
     static bool TypeIsSupported(ITypeData td)
     {
         var type = td.AsTypeData().Type;
-        return type == typeof(double) || type == typeof(bool) || type == typeof(int) || type == typeof(string);
+
+        var isSupportedDoubleType = type == typeof(double) || type == typeof(double?);
+        var isSupportedBoolType = type == typeof(bool) || type == typeof(bool?);
+        var isSupportedIntType = type == typeof(int) || type == typeof(int?);
+
+        return isSupportedDoubleType || isSupportedBoolType || isSupportedIntType || type == typeof(string);
     }
 
     private static readonly ConcurrentDictionary<ITypeData, IMetricSource> _metricProducers =
@@ -120,6 +125,12 @@ public static class MetricManager
     public static void PushMetric(MetricInfo metric, string value)
     {
         PushMetric(new StringMetric(metric, value));
+    }
+
+    /// <summary> Push an empty metric. </summary>
+    public static void PushMetric(MetricInfo metric)
+    {
+        PushMetric(new EmptyMetric(metric));
     }
 
     /// <summary>
@@ -173,6 +184,9 @@ public static class MetricManager
                     break;
                 case string v:
                     yield return new StringMetric(metric, v);
+                    break;
+                case null:
+                    yield return new EmptyMetric(metric);
                     break;
                 default:
                     log.ErrorOnce(metric, "Metric value is not a supported type: {0} of type {1}", metric.Name, metricValue?.GetType().Name ?? "null");

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -229,39 +229,15 @@ public static class MetricManager
         return mi;
     }
 
-    public static MetricInfo CreatePollMetric<T>(IAdditionalMetricSources owner, Func<T> pollFunction, string name, string groupName) where T : IConvertible
+    public static MetricInfo CreatePollMetric<T>(IAdditionalMetricSources owner, Func<T> pollFunction, string name, string groupName)
     {
         if (pollFunction == null)
             throw new ArgumentNullException(nameof(pollFunction));
         return CreateMetric<T>(owner, name, groupName, MetricKind.Poll, pollFunction);
     }
 
-    public static MetricInfo CreateNullablePollMetric<T>(IAdditionalMetricSources owner, Func<T> pollFunction, string name, string groupName)
-    {
-        if (pollFunction is null)
-            throw new ArgumentNullException(nameof(pollFunction));
-
-        EnsureNullableMetricIsValid<T>();
-        return CreateMetric(owner, name, groupName, MetricKind.Poll, pollFunction);
-    }
-
-    public static MetricInfo CreatePushMetric<T>(IAdditionalMetricSources owner, string name, string groupName) where T : IConvertible
+    public static MetricInfo CreatePushMetric<T>(IAdditionalMetricSources owner, string name, string groupName)
     {
         return CreateMetric<T>(owner, name, groupName, MetricKind.Push, null);
-    }
-
-    public static MetricInfo CreateNullablePushMetric<T>(IAdditionalMetricSources owner, string name, string groupName)
-    {
-        EnsureNullableMetricIsValid<T>();
-        return CreateMetric<T>(owner, name, groupName, MetricKind.Push, null);
-    }
-
-    private static void EnsureNullableMetricIsValid<T>()
-    {
-        var underlyingType = Nullable.GetUnderlyingType(typeof(T));
-        if (underlyingType.GetInterface(nameof(IConvertible)) is null)
-        {
-            throw new InvalidOperationException($"Unsupported type '{typeof(T)}' is not a 'System.IConvertible' type");
-        }
     }
 }

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -185,7 +185,7 @@ public static class MetricManager
                 case string v:
                     yield return new StringMetric(metric, v);
                     break;
-                case null when metric.Type.HasFlag(MetricType.Nullable & MetricType.String):
+                case null when metric.Type.HasFlag(MetricType.Nullable) || metric.Type.HasFlag(MetricType.String):
                     // String metrics does also support null values, but does not use the nullable flag.
                     yield return new EmptyMetric(metric);
                     break;

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -93,10 +93,11 @@ public static class MetricManager
                     if (_pushMetricInfos.TryGetValue(mem, out var existingMetricInfo))
                     {
                         yield return existingMetricInfo;
-                        continue;
                     }
-
-                    yield return new MetricInfo(mem, member.Key, metricSource);
+                    else
+                    {
+                        yield return new MetricInfo(mem, member.Key, metricSource);
+                    }
                 }
             }
             if (metricSource is IAdditionalMetricSources source2)

--- a/OpenTap.Metrics/MetricType.cs
+++ b/OpenTap.Metrics/MetricType.cs
@@ -2,12 +2,16 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+
 namespace OpenTap.Metrics;
 
+[Flags]
 public enum MetricType
 {
-    Unknown,
-    Double,
-    Boolean,
-    String
+    Unknown = 0,
+    Double = 1,
+    Boolean = 2,
+    String = 4,
+    Nullable = 8
 }


### PR DESCRIPTION
Whenever a supported metric value is null it is created as a new empty metric struct
Closes #43 