### PR TITLE
Added AssetDiscovery base class to help ensure proper/consistent impl…

### DIFF
--- a/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
+++ b/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
@@ -39,6 +39,11 @@ public abstract class AssetDiscovery : ValidatingObject, IAssetDiscovery
 {
     private string _name;
 
+    /// <summary>
+    /// A name short name of this asset discovery provider/implementation.
+    /// For use in UIs that list instances. Same function as the Name property on OpenTap.IResource.
+    /// Deriving classes should set this property in their constructor.
+    /// </summary>
     [Display("Asset Discovery Name", "The name of the this asset discovery provider/implementation. ")]
     public string Name
     {

--- a/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
+++ b/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace OpenTap.Metrics.AssetDiscovery;
 
@@ -21,6 +22,35 @@ public interface IAssetDiscovery : OpenTap.ITapPlugin
     DiscoveryResult DiscoverAssets();
 }
 
+/// <summary>
+/// Base class for asset discovery implementations.
+/// This is a convenience class that implements the IAssetDiscovery interface.
+/// </summary>
+[Display("")]
+public abstract class AssetDiscovery : ValidatingObject, IAssetDiscovery
+{
+    /// <summary>
+    /// A name short name of this asset discovery provider/implementation.
+    /// For use in UIs that list instances. Same function as the Name property on OpenTap.IResource.
+    /// Derived classes should set this property in their constructor.
+    /// </summary>
+    [Browsable(false)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Sets the priority of this provider. In case two implementations return the same
+    /// discovered asset (same Identifier), the one from the higher priority provider is used
+    /// </summary>
+    public double Priority { get; set; } = 0;
+
+    public abstract DiscoveryResult DiscoverAssets();
+
+    /// <summary>
+    /// Overrides ToString() to return the Name.
+    /// </summary>
+    public override string ToString() => Name;
+}
+
 public class DiscoveryResult
 {
     /// <summary>
@@ -40,7 +70,6 @@ public class DiscoveryResult
     /// </summary>
     public IEnumerable<DiscoveredAsset> Assets { get; set; }
 }
-
 
 /// <summary>
 /// Represents a discovered asset.

--- a/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
+++ b/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
@@ -11,6 +11,14 @@ namespace OpenTap.Metrics.AssetDiscovery;
 public interface IAssetDiscovery : OpenTap.ITapPlugin
 {
     /// <summary>
+    /// A name short name of this asset discovery provider/implementation.
+    /// For use in UIs that list instances. Same function as the Name property on OpenTap.IResource.
+    /// Inheriting classes should set this property in their constructor.
+    /// </summary>
+    [Browsable(false)]
+    string Name { get; set; }
+
+    /// <summary>
     /// Sets the priority of this provider. In case two implementations return the same 
     /// discovered asset (same Identifier), the one from the higher priority provider is used
     /// </summary>
@@ -29,13 +37,21 @@ public interface IAssetDiscovery : OpenTap.ITapPlugin
 [Display("")]
 public abstract class AssetDiscovery : ValidatingObject, IAssetDiscovery
 {
-    /// <summary>
-    /// A name short name of this asset discovery provider/implementation.
-    /// For use in UIs that list instances. Same function as the Name property on OpenTap.IResource.
-    /// Derived classes should set this property in their constructor.
-    /// </summary>
-    [Browsable(false)]
-    public string Name { get; set; }
+    private string _name;
+
+    [Display("Asset Discovery Name", "The name of the this asset discovery provider/implementation. ")]
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value), "Asset Discovery Name cannot be null.");
+            if (value == _name) return;
+            _name = value;
+            OnPropertyChanged(nameof(Name));
+        }
+    }
 
     /// <summary>
     /// Sets the priority of this provider. In case two implementations return the same


### PR DESCRIPTION
…ementation of Name property similar to IResource/Resource

IAssetDiscovery implementations should have a Name property, and it should be [Browsable(false)] just like OpenTap.Resource.

Without a Name property, the item in the master view here is emply:
![Image](https://github.com/user-attachments/assets/70979423-a8ee-4dbe-884c-3aec6788fb42)

